### PR TITLE
Added missing include of <stdio.h> to libcerror.h for the functions which have FILE* as a parameter

### DIFF
--- a/include/libcerror.h.in
+++ b/include/libcerror.h.in
@@ -27,6 +27,8 @@
 #include <libcerror/features.h>
 #include <libcerror/types.h>
 
+#include <stdio.h>
+
 #if defined( __cplusplus )
 extern "C" {
 #endif


### PR DESCRIPTION
libcerror.h declares functions which have FILE* parameters but does not include <stdio.h>. This patches that problem.