### PR TITLE
allow rhel dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 AC_INIT(
  [libcerror],
@@ -33,7 +33,7 @@ AC_PATH_PROG(PKGCONFIG,[pkg-config])
 
 dnl Support of internationalization (i18n)
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.21])
+AM_GNU_GETTEXT_VERSION([0.19])
 
 dnl Check for compiler language support
 AC_C_CONST


### PR DESCRIPTION
Hello,
there are older versions of gettext and autoconf on RHEL, but still builds well. Please could you consider lowering the minimum requirements in the upstream?

For example:
- Build for Fedora/RHEL with the current requirements https://copr.fedorainfracloud.org/coprs/rebus/infosec/build/6569804/

- Build for Fedora/RHEL with the lowered requirements  https://copr.fedorainfracloud.org/coprs/rebus/infosec/build/6569899/

Thank you
Michal Ambroz